### PR TITLE
Update hero.css

### DIFF
--- a/src/css/hero.css
+++ b/src/css/hero.css
@@ -13,6 +13,13 @@
   background-position: center;
   border-radius: 30px;
 }
+@media only screen and (min-width: 768px) {
+  .hero-container {
+    padding-left: 40px;
+    padding-right: 40px;
+    padding-bottom: 40px;
+  }
+}
 .hero-section {
   padding-bottom: 72px;
 }
@@ -215,9 +222,17 @@
 }
 .hero-skroll-icon {
   background-color: var(--light-color);
+  padding: 6px;
   border-radius: 50%;
   fill: var(--brand-color);
   transition: var(--transition-timings);
+}
+@media only screen and (min-width: 768px) {
+  .hero-skroll-icon {
+    width: 38px;
+    height: 38px;
+    padding: 8px;
+  }
 }
 .hero-skroll-icon:hover,
 .hero-skroll-icon:focus {


### PR DESCRIPTION
правки:
медіа правило для бокових і нижнього падінгів контейнера на планшеті і на десктопі 40рх, падінг для вектору scroll down 6рх.
і медіа для планшету і десктопу - розміри кнопки 38px padding 8px